### PR TITLE
Scope cnpmjs.org to @qutics

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ cnpmjs.org
 
 ![logo](https://raw.github.com/cnpm/cnpmjs.org/master/logo.png)
 
+## Qubit-specific notes
+
+This is a fork of [`cnpmjs.org`](https://github.com/cnpm/cnpmjs.org), modified to
+work as a backend to [`enporium`](https://github.com/qubitdigital/enporium).
+
+We've renamed it to `@qutics/cnpmjs.org` and published it to our own private
+registry so that it can be an `enporium` dependency as an npm-style package,
+the caching of which seems to be handled more predictably by `yarn` than are
+GitHub dependencies. We're versioning it starting at `0.1.0`.
+
+The plan is to eventually switch back to the official `cnpmjs.org` package,
+if and when we have time to collaborate with them on some pull requests we would need.
+
 ## What is this?
 
 Private npm registry and web for Enterprise, base on [koa](http://koajs.com/),

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "cnpmjs.org",
-  "version": "1.7.6",
-  "description": "Private npm registry and web for Enterprise, base on MySQL and Simple Store Service",
+  "name": "@qutics/cnpmjs.org",
+  "version": "0.1.0",
+  "description": "The original cnpmjs.org modified to work with enporium and scoped to @qutics",
   "main": "index.js",
   "scripts": {
     "test": "make install && make jshint && make test",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qutics/cnpmjs.org",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "The original cnpmjs.org modified to work with enporium and scoped to @qutics",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Yarn seems to be unpredictable when it comes to github-based dependencies, so we're scoping cnpmjs.org to @qutics and publishing it to enporium itself to use as a dependency to enporium (not the first such circular dependency).

As of writing this, `@qutics/cnpmjs.org-0.2.0` is already published.